### PR TITLE
fix(cargo deps): do not use tilde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ proc-macro = true
 
 [dependencies]
 lazy_static = "1.4.0"
-proc-macro2 = "~1.0.64"
-quote = "~1.0.31"
-syn = { version = "~2.0.25", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0.64"
+quote = "1.0.31"
+syn = { version = "2.0.25", features = ["full", "extra-traits"] }
 thiserror = "1.0.43"
 try_match = "0.4.1"
 str_inflector = "0.12.0"
 
 [dev-dependencies]
-trybuild = "~1.0.81"
+trybuild = "1.0.81"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 insta = "1.30.0"
 rust-format = "0.3.4"


### PR DESCRIPTION
# Why?

This library should not use [Tilde requirements](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements) in `Cargo.toml` because it's uselessly restrictive.

For example, requiring `quote = "~1.0.31"` will prevent buildstructor's users to use `quote "1.1.0"` when it will be released. It means that they will have to wait for `buildstructor` to bump a new release that allows this new minor version of `quote`.